### PR TITLE
Update Find-DhcpServerv4ScopeID.psm1

### DIFF
--- a/Find-DhcpServerv4ScopeID/Find-DhcpServerv4ScopeID.psm1
+++ b/Find-DhcpServerv4ScopeID/Find-DhcpServerv4ScopeID.psm1
@@ -43,7 +43,8 @@ function Find-DhcpServerv4ScopeID
 
         $all_scopes = Get-DhcpServerv4Scope -ComputerName $ComputerName
         $number_of_scopes = $all_scopes.Count
-
+        $counter = -1
+         
         Do
         {
             $counter = $counter+1                                 


### PR DESCRIPTION
Function never searches in in first scope (index 0) on server thanks to this line "$counter = $counter+1"
Simpliest solution is to initialize variable with -1 above.
I am new to github, hope it hepls.
Martin